### PR TITLE
Constraints with prereleases and mismatched segments

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -140,10 +140,8 @@ func prereleaseCheck(v, c *Version) bool {
 		// A constraint with a pre-release can only match a pre-release version
 		// with the same base segments.
 		return reflect.DeepEqual(c.Segments64(), v.Segments64())
-
 	case !cPre && vPre:
-		// OK per https://semver.org/#spec-item-11 (#3)
-
+		// OK, per https://semver.org/#spec-item-11 (#3)
 	case cPre && !vPre:
 		// OK, except with the pessimistic operator
 	case !cPre && !vPre:
@@ -165,15 +163,15 @@ func constraintNotEqual(v, c *Version) bool {
 }
 
 func constraintGreaterThan(v, c *Version) bool {
-	return prereleaseCheck(v, c) && v.Compare(c) == 1
+	return v.Compare(c) == 1
 }
 
 func constraintLessThan(v, c *Version) bool {
-	return prereleaseCheck(v, c) && v.Compare(c) == -1
+	return v.Compare(c) == -1
 }
 
 func constraintGreaterThanEqual(v, c *Version) bool {
-	return prereleaseCheck(v, c) && v.Compare(c) >= 0
+	return v.Compare(c) >= 0
 }
 
 func constraintLessThanEqual(v, c *Version) bool {

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -89,11 +89,11 @@ func TestConstraintCheck(t *testing.T) {
 		{"> 2.0", "2.0.0-beta", false},
 		{">= 2.0", "2.0.0-beta", false},
 		{">= 2.1.0-a", "2.1.0-beta", true},
-		{">= 2.1.0-a", "2.1.1-beta", false},
-		{">= 2.0.0", "2.1.0-beta", true}, // https://semver.org/#spec-item-11 (#3)
+		{">= 2.1.0-a", "2.1.1-beta", true}, // segment comparison takes precedence over prerelease comparison, but is still valid to compare
+		{">= 2.0.0", "2.1.0-beta", true},   // https://semver.org/#spec-item-11 (#3)
 		{">= 2.0.0", "2.0.0-beta", false},
 		{">= 2.1.0-a", "2.1.1", true},
-		{">= 2.1.0-a", "2.1.1-beta", false},
+		{">= 2.1.0-a", "2.1.1-beta", true}, // segment comparison takes precedence over prerelease comparison, but is still valid to compare
 		{">= 2.1.0-a", "2.1.0", true},
 		{"<= 2.1.0-a", "2.0.0", true},
 		{"^1.1", "1.1.1", true},
@@ -125,6 +125,10 @@ func TestConstraintCheck(t *testing.T) {
 		{"< 1.0.0-rc.1", "1.0.0", false},
 		{"< 1.0.0", "1.0.0-rc.1", true},
 		{"> 1.0.0", "1.0.0-rc.1", false},
+		{"< 0.9.12-r1", "0.9.9-r0", true},  // regression
+		{"< 0.9.9-r1", "0.9.9-r0", true},   // regression
+		{"< 0.9.9-r1", "0.9.9-r11", false}, // regression
+		{"> 0.9.9-r1", "0.9.9-r11", true},  // regression
 	}
 
 	for _, tc := range cases {
@@ -141,7 +145,7 @@ func TestConstraintCheck(t *testing.T) {
 		actual := c.Check(v)
 		expected := tc.check
 		if actual != expected {
-			t.Fatalf("Version: %s\nConstraint: %s\nExpected: %#v",
+			t.Errorf("\nVersion: %s\nConstraint: %s\nExpected: %#v",
 				tc.version, tc.constraint, expected)
 		}
 	}

--- a/version.go
+++ b/version.go
@@ -173,7 +173,7 @@ func (v *Version) Compare(other *Version) int {
 		} else if lhs < rhs {
 			return -1
 		}
-		// Otherwis, rhs was > lhs, they're not equal
+		// Otherwise, rhs was > lhs, they're not equal
 		return 1
 	}
 

--- a/version_test.go
+++ b/version_test.go
@@ -234,6 +234,8 @@ func TestComparePreReleases(t *testing.T) {
 		{"1.0.0-rc.1", "1.0.0", -1},
 		//{"1.0.0-rc9", "1.0.0-rc10", -1}, // want to support one day
 		//{"v1.0.0-rc9", "1.0.0-rc10", -1}, // want to support one day
+		{"0.9.9-r0", "0.9.12-r1", -1}, // regression
+		{"0.9.9-r0", "0.9.9-r1", -1},  // regression
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
The following constraint case should resolve to true `0.9.9-r0 < 0.9.12-r1` which this PR now accounts for.